### PR TITLE
Fix trmm

### DIFF
--- a/polybench-cuda/trmm/trmm.c
+++ b/polybench-cuda/trmm/trmm.c
@@ -31,8 +31,8 @@ void init_array(int n,int m,
 
 static void kernel(int n, int m,
                    double alpha,
-                   double *B,
-                   double *A) {
+                   double *A,
+                   double *B) {
   for (int i = 0; i < m; i++)
     for (int j = 0; j < n; j++) {
       for (int k = i + 1; k < m; k++)

--- a/polybench-cuda/trmm/trmm_omp.c
+++ b/polybench-cuda/trmm/trmm_omp.c
@@ -31,8 +31,8 @@ void init_array(int n,int m,
 
 static void kernel(int n, int m,
                    double alpha,
-                   double *B,
-                   double *A) {
+                   double *A,
+                   double *B) {
   for (int i = 0; i < m; i++)
     for (int j = 0; j < n; j++) {
       for (int k = i + 1; k < m; k++)

--- a/polybench-cuda/trmm/trmm_omp.c
+++ b/polybench-cuda/trmm/trmm_omp.c
@@ -63,8 +63,8 @@ void print_array(int m, int n,
 static
 void kernel_trmm(int n, int m,
 		 double alpha,
-		 double A[n][m],
-		 double B[m][n])
+		 double *A,
+		 double *B)
 {
   int i, j, k;
 
@@ -74,12 +74,12 @@ void kernel_trmm(int n, int m,
     for (int j = 0; j < n; j++)
       for (int i = 0; i < m; i++)
         for (int k = i + 1; k < m; k++)
-          B[i][j] += A[k][i] * B[k][j];
+          B[i*n+j] += A[k*m+i] * B[k*n+j];
 
 #pragma omp for collapse(2) schedule(static)
     for (int i = 0; i < m; i++)
       for (int j = 0; j < n; j++)
-        B[i][j] *= alpha;
+        B[i*n+j] *= alpha;
 }
 
 }

--- a/polybench-cuda/trmm/trmm_omp.c
+++ b/polybench-cuda/trmm/trmm_omp.c
@@ -101,7 +101,7 @@ int main(int argc, char** argv)
   init_array (n,m, &alpha, A, B);
 
   /* Run kernel. */
-  kernel(n,m, alpha, A, B);
+  kernel_trmm(n,m, alpha, A, B);
 
   /* Prevent dead-code elimination. All live-out data must be printed
      by the function call in argument. */


### PR DESCRIPTION
Fixes order of arguments in kernel function. Also updates kernel_trmm to avoid compiler warnings and uses this for running OpenMP.

- [ ] Seems tulip output for TEST_ARGS does not match.
- [ ] gcc outputs also dont match