### PR TITLE
Fix OpenMP code for GCC compiler

### DIFF
--- a/polybench-cuda/trmm/trmm_omp.c
+++ b/polybench-cuda/trmm/trmm_omp.c
@@ -22,6 +22,14 @@ void init_array(int n,int m,
   int i, j;
 
   *alpha = 32412;
+
+  // Initialize B to zero as only diagonals are set below
+  for (i = 0; i < m; i++) {
+    for (j = 0; j < n; j++) {
+      B[i*n + j] = 0.0;
+    }
+  }
+
   for (i = 0; i < n; i++)
     for (j = 0; j < m; j++) {
       A[i*m+j] = ((double) i*j) / m;


### PR DESCRIPTION
OpenMP results with the GCC compiler were wrong because matrix B is not fully initialized (only the non-zero diagonal values get initialized).

Clang appears to default the array to zero values.

The same issue exists in trmm.cu, also effecting GCC results.
