### PR TITLE
Fix to adi row sweep

### DIFF
--- a/polybench-cuda/adi/adi.c
+++ b/polybench-cuda/adi/adi.c
@@ -85,7 +85,7 @@ static void kernel(
     // Row Sweep
     for (int i = 1; i < n - 1; i++) {
     u[i * n + 0] = 1;
-    p[i + n + 0] = 0;
+    p[i * n + 0] = 0;
     q[i * n + 0] = u[i * n + 0];
     for (int j = 1; j < n - 1; j++) {
       p[i * n + j] = -f / (d * p[i * n + j - 1] + e);

--- a/polybench-cuda/adi/adi_omp.c
+++ b/polybench-cuda/adi/adi_omp.c
@@ -89,7 +89,7 @@ static void kernel(
     #pragma omp for schedule(static)
     for (int i = 1; i < n - 1; i++) {
     u[i * n + 0] = 1;
-    p[i + n + 0] = 0;
+    p[i * n + 0] = 0;
     q[i * n + 0] = u[i * n + 0];
     for (int j = 1; j < n - 1; j++) {
       p[i * n + j] = -f / (d * p[i * n + j - 1] + e);


### PR DESCRIPTION
Fix to the indexing in row sweep.

The `+ 0` also seems redundant, but I  have left it alone as I assume it's a style choice. 

